### PR TITLE
Revert "Bump nokogiri from 1.13.10 to 1.14.3"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,11 +69,9 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
-    nokogiri (1.14.3-arm64-darwin)
+    nokogiri (1.13.10-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.14.3-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.14.3-x86_64-linux)
+    nokogiri (1.13.10-x86_64-darwin)
       racc (~> 1.4)
     parallel (1.21.0)
     parser (3.0.3.2)
@@ -123,7 +121,6 @@ PLATFORMS
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21
-  x86_64-linux
 
 DEPENDENCIES
   addressable (>= 2.8.0)


### PR DESCRIPTION
Reverts kapresoft/kapresoft.github.io#11

## Reason
This update requires ruby 4.